### PR TITLE
fix: 深色模式适配 — 全部颜色跟随 DSW 主题变量

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -41,7 +41,7 @@ window.__ModuleLoader__.load({
   backdrop-filter: blur(18px) saturate(1.2);
   -webkit-backdrop-filter: blur(18px) saturate(1.2);
   color: var(--dsw-alias-label-primary, #2b2b33);
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--dsw-alias-border-l2-darkmode-thin, rgba(0, 0, 0, 0.08));
   border-radius: 18px;
   box-shadow:
     0 24px 60px rgba(0, 0, 0, 0.18),
@@ -50,6 +50,13 @@ window.__ModuleLoader__.load({
   font-size: 13px;
   animation: sn-pop 0.18s cubic-bezier(0.34, 1.56, 0.64, 1);
   overflow: hidden;
+}
+/* 深色模式：玻璃面板换深色底，阴影加深（半透明底没有现成 alias token） */
+body[data-ds-dark-theme] .sn-panel {
+  background: rgba(27, 27, 28, 0.92);
+  box-shadow:
+    0 24px 60px rgba(0, 0, 0, 0.55),
+    0 4px 14px rgba(0, 0, 0, 0.45);
 }
 /* 自定义伸缩手柄：左边缘、上边缘、左上角 */
 .sn-rz-left {
@@ -138,7 +145,7 @@ window.__ModuleLoader__.load({
 }
 .sn-x {
   border: 1px solid var(--dsw-alias-border-l2-darkmode-thin, rgba(0, 0, 0, 0.12));
-  background: #fff;
+  background: var(--dsw-specific-input-major, #fff);
   color: var(--dsw-alias-label-secondary, #6b6b76);
   width: 22px;
   height: 22px;
@@ -172,10 +179,10 @@ window.__ModuleLoader__.load({
 }
 .sn-plus:hover { background: var(--dsw-alias-button-info-hover, #2563eb); transform: scale(1.06); }
 .sn-hist {
-  background: #fff;
+  background: var(--dsw-specific-input-major, #fff);
   border: 1px solid var(--dsw-alias-border-l2-darkmode-thin, rgba(0, 0, 0, 0.12));
 }
-.sn-hist:hover:not(.sn-active) { background: #f5f9ff; border-color: var(--dsw-alias-button-info-fill, #3b82f6); }
+.sn-hist:hover:not(.sn-active) { background: var(--dsw-alias-interactive-bg-hover-accent, #f5f9ff); border-color: var(--dsw-alias-button-info-fill, #3b82f6); }
 .sn-hist.sn-active { background: var(--dsw-alias-button-info-fill, #3b82f6); border-color: transparent; color: #fff; }
 .sn-openfolder {
   display: inline-flex;
@@ -183,7 +190,7 @@ window.__ModuleLoader__.load({
   justify-content: center;
   width: 30px;
   height: 30px;
-  background: #fff;
+  background: var(--dsw-specific-input-major, #fff);
   border: 1px solid var(--dsw-alias-border-l2-darkmode-thin, rgba(0, 0, 0, 0.12));
   color: var(--dsw-alias-label-secondary, #4a4a55);
   border-radius: 8px;
@@ -191,11 +198,11 @@ window.__ModuleLoader__.load({
   padding: 0;
   transition: all 0.12s ease;
 }
-.sn-openfolder:hover { background: #f5f9ff; border-color: var(--dsw-alias-button-info-fill, #3b82f6); color: var(--dsw-alias-button-info-fill, #3b82f6); }
+.sn-openfolder:hover { background: var(--dsw-alias-interactive-bg-hover-accent, #f5f9ff); border-color: var(--dsw-alias-button-info-fill, #3b82f6); color: var(--dsw-alias-button-info-fill, #3b82f6); }
 .sn-openfolder svg { flex: none; }
 .sn-back-text {
   border: 1px solid var(--dsw-alias-border-l2-darkmode-thin, rgba(0, 0, 0, 0.12));
-  background: #fff;
+  background: var(--dsw-specific-input-major, #fff);
   color: var(--dsw-alias-label-primary, #2b2b33);
   border-radius: 8px;
   cursor: pointer;
@@ -210,11 +217,11 @@ window.__ModuleLoader__.load({
 .sn-back-text:hover {
   border-color: var(--dsw-alias-button-info-fill, #3b82f6);
   color: var(--dsw-alias-button-info-fill, #3b82f6);
-  background: #f5f9ff;
+  background: var(--dsw-alias-interactive-bg-hover-accent, #f5f9ff);
 }
 .sn-help {
   border: 1px solid var(--dsw-alias-border-l2-darkmode-thin, rgba(0, 0, 0, 0.12));
-  background: #fff;
+  background: var(--dsw-specific-input-major, #fff);
   color: var(--dsw-alias-label-secondary, #6b6b76);
   width: 22px;
   height: 22px;
@@ -508,8 +515,8 @@ window.__ModuleLoader__.load({
   opacity: 0;
   transition: opacity 0.12s ease;
   border: none;
-  background: rgba(255, 80, 80, 0.12);
-  color: #d54545;
+  background: var(--dsw-alias-interactive-bg-hover-danger, rgba(255, 80, 80, 0.12));
+  color: var(--dsw-alias-state-error-primary, #d54545);
   border-radius: 7px;
   cursor: pointer;
   padding: 3px 9px;
@@ -517,7 +524,7 @@ window.__ModuleLoader__.load({
   flex-shrink: 0;
 }
 .sn-row:hover .sn-arch { opacity: 1; }
-.sn-arch:hover { background: rgba(255, 80, 80, 0.22); color: #b03a3a; }
+.sn-arch:hover { background: rgba(223, 82, 82, 0.22); color: var(--dsw-alias-state-error-secondary, #b03a3a); }
 /* 单击记录后：归档 → 发送 的切换动画 */
 .sn-row.sn-pending { background: var(--dsw-alias-interactive-bg-hover, rgba(0, 0, 0, 0.05)); }
 .sn-sendrow {
@@ -788,7 +795,7 @@ window.__ModuleLoader__.load({
 .sn-note-edit {
   flex: none;
   border: 1px solid var(--dsw-alias-border-l2-darkmode-thin, rgba(0, 0, 0, 0.12));
-  background: #fff;
+  background: var(--dsw-specific-input-major, #fff);
   color: var(--dsw-alias-label-secondary, #6b6b76);
   border-radius: 8px;
   cursor: pointer;
@@ -797,11 +804,11 @@ window.__ModuleLoader__.load({
   font-weight: 600;
   transition: all 0.12s ease;
 }
-.sn-note-edit:hover { border-color: var(--dsw-alias-button-info-fill, #3b82f6); color: var(--dsw-alias-button-info-fill, #3b82f6); background: #f5f9ff; }
+.sn-note-edit:hover { border-color: var(--dsw-alias-button-info-fill, #3b82f6); color: var(--dsw-alias-button-info-fill, #3b82f6); background: var(--dsw-alias-interactive-bg-hover-accent, #f5f9ff); }
 .sn-note-cancel {
   flex: none;
   border: 1px solid var(--dsw-alias-border-l2-darkmode-thin, rgba(0, 0, 0, 0.12));
-  background: #fff;
+  background: var(--dsw-specific-input-major, #fff);
   color: var(--dsw-alias-label-secondary, #6b6b76);
   border-radius: 8px;
   cursor: pointer;
@@ -809,7 +816,7 @@ window.__ModuleLoader__.load({
   font-size: 12px;
   transition: all 0.12s ease;
 }
-.sn-note-cancel:hover { border-color: rgba(255, 80, 80, 0.5); color: #d54545; }
+.sn-note-cancel:hover { border-color: rgba(223, 82, 82, 0.5); color: var(--dsw-alias-state-error-primary, #d54545); }
 .sn-note-textarea { min-height: 120px; }
 `
 


### PR DESCRIPTION
Closes #2

## 问题

深色模式下便签面板仍是浅色玻璃底，顶部标题文字变成白色导致看不清；右下角按钮又呈深色，配色前后不一致（即 #2 反馈的现象）。

根因：样式里混了一批硬编码浅色值——白底按钮（✕ 关闭、历史便签、帮助、返回、编辑、取消、文件夹）、浅蓝 hover 底 #f5f9ff、归档红色按钮、面板白色半透明底。这些不随主题切换。

## 改法

让所有颜色跟随主题体系自动切换，而非自行判断深浅模式。DSH 主题机制是在 `body` 上切换 `data-ds-dark-theme` 属性并整体翻转 `--dsw-alias-*` 变量（见 dsh-client-ui-theme 的 design-platform.css），因此：

- 白底按钮 → `var(--dsw-specific-input-major)`（深浅两套值）
- 浅蓝 hover 底 → `var(--dsw-alias-interactive-bg-hover-accent)`
- 归档红按钮 → `--dsw-alias-state-error-primary` / `--dsw-alias-state-error-secondary`
- 面板边框 → `--dsw-alias-border-l2-darkmode-thin`
- 玻璃面板半透明底无现成 token：浅色保留原值，另加 `body[data-ds-dark-theme] .sn-panel` 覆盖为深色半透明底并加深阴影

## 验证

- 提取插件 CSS 配真实 design-platform.css 搭静态页，覆盖编辑面板 / 历史列表 / Markdown 查看 / 查看+编辑态 / 设置卡片 / 各按钮态，深浅两主题分别截图，视觉模型逐面板检查通过
- pnpm link 安装的 DSH Desktop 重启后确认加载的是适配后代码